### PR TITLE
HTTP daemon server: API routes and lifecycle

### DIFF
--- a/src/http/mod.ts
+++ b/src/http/mod.ts
@@ -1,1 +1,2 @@
-// Adapter: Deno.serve HTTP server. Receives wired domain functions from main.ts.
+export { createServer } from "./server.ts";
+export type { Server, ServerDeps } from "./server.ts";

--- a/src/http/server.test.ts
+++ b/src/http/server.test.ts
@@ -1,0 +1,250 @@
+import { assertEquals } from "@std/assert";
+import { createServer, type ServerDeps } from "./server.ts";
+
+function stubDeps(overrides: Partial<ServerDeps> = {}): ServerDeps {
+  return {
+    navigate: () =>
+      Promise.resolve({ name: "default", url: "https://example.com", targetId: "t1" }),
+    evaluate: () => Promise.resolve({ result: 42 }),
+    screenshot: () => Promise.resolve("/tmp/screenshot.png"),
+    listPages: () => Promise.resolve([]),
+    closePage: () => Promise.resolve(),
+    snapshot: () => Promise.resolve({ yaml: "- heading" }),
+    ...overrides,
+  };
+}
+
+function json(body: unknown): RequestInit {
+  return {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  };
+}
+
+// --- GET /health ---
+
+Deno.test("GET /health returns status ok with page list", async () => {
+  const pages = [{ name: "default", url: "https://example.com", targetId: "t1" }];
+  const server = createServer(stubDeps({ listPages: () => Promise.resolve(pages) }));
+  const res = await server.request("/health");
+  assertEquals(res.status, 200);
+  assertEquals(await res.json(), { status: "ok", pages });
+});
+
+// --- POST /pages ---
+
+Deno.test("POST /pages navigates and returns page info", async () => {
+  const server = createServer(stubDeps());
+  const res = await server.request("/pages", json({ url: "https://example.com" }));
+  assertEquals(res.status, 200);
+  assertEquals(await res.json(), { name: "default", url: "https://example.com", targetId: "t1" });
+});
+
+Deno.test("POST /pages uses provided name", async () => {
+  const server = createServer(stubDeps({
+    navigate: (req) => Promise.resolve({ name: req.name!, url: req.url, targetId: "t2" }),
+  }));
+  const res = await server.request("/pages", json({ name: "mypage", url: "https://example.com" }));
+  assertEquals(res.status, 200);
+  const body = await res.json();
+  assertEquals(body.name, "mypage");
+});
+
+Deno.test("POST /pages requires url", async () => {
+  const server = createServer(stubDeps());
+  const res = await server.request("/pages", json({}));
+  assertEquals(res.status, 400);
+  const body = await res.json();
+  assertEquals(body.error, "url is required");
+});
+
+// --- DELETE /pages/:name ---
+
+Deno.test("DELETE /pages/:name closes the page", async () => {
+  let closedName = "";
+  const server = createServer(stubDeps({
+    closePage: (name) => {
+      closedName = name;
+      return Promise.resolve();
+    },
+  }));
+  const res = await server.request("/pages/mypage", { method: "DELETE" });
+  assertEquals(res.status, 200);
+  assertEquals(await res.json(), { ok: true });
+  assertEquals(closedName, "mypage");
+});
+
+// --- GET /pages ---
+
+Deno.test("GET /pages returns page list", async () => {
+  const pages = [
+    { name: "default", url: "https://a.com", targetId: "t1" },
+    { name: "other", url: "https://b.com", targetId: "t2" },
+  ];
+  const server = createServer(stubDeps({ listPages: () => Promise.resolve(pages) }));
+  const res = await server.request("/pages");
+  assertEquals(res.status, 200);
+  assertEquals(await res.json(), pages);
+});
+
+// --- POST /snapshot ---
+
+Deno.test("POST /snapshot returns yaml", async () => {
+  const server = createServer(stubDeps({
+    snapshot: () => Promise.resolve({ yaml: '- main:\n    - heading "Hello"' }),
+  }));
+  const res = await server.request("/snapshot", json({ name: "default" }));
+  assertEquals(res.status, 200);
+  assertEquals(await res.json(), { yaml: '- main:\n    - heading "Hello"' });
+});
+
+Deno.test("POST /snapshot defaults name to default", async () => {
+  let receivedName = "";
+  const server = createServer(stubDeps({
+    snapshot: (opts) => {
+      receivedName = opts.name ?? "";
+      return Promise.resolve({ yaml: "- heading" });
+    },
+  }));
+  await server.request("/snapshot", json({}));
+  assertEquals(receivedName, "default");
+});
+
+Deno.test("POST /snapshot passes options through", async () => {
+  let receivedOpts: Record<string, unknown> = {};
+  const server = createServer(stubDeps({
+    snapshot: (opts) => {
+      receivedOpts = { ...opts };
+      return Promise.resolve({ yaml: "- heading" });
+    },
+  }));
+  await server.request(
+    "/snapshot",
+    json({ name: "p1", maxDepth: 5, maxNodes: 100, selector: "#main" }),
+  );
+  assertEquals(receivedOpts.name, "p1");
+  assertEquals(receivedOpts.maxDepth, 5);
+  assertEquals(receivedOpts.maxNodes, 100);
+  assertEquals(receivedOpts.selector, "#main");
+});
+
+// --- POST /eval ---
+
+Deno.test("POST /eval returns result", async () => {
+  const server = createServer(stubDeps({
+    evaluate: () => Promise.resolve({ result: { title: "Test" } }),
+  }));
+  const res = await server.request(
+    "/eval",
+    json({ name: "default", expression: "document.title" }),
+  );
+  assertEquals(res.status, 200);
+  assertEquals(await res.json(), { result: { title: "Test" } });
+});
+
+Deno.test("POST /eval requires expression", async () => {
+  const server = createServer(stubDeps());
+  const res = await server.request("/eval", json({ name: "default" }));
+  assertEquals(res.status, 400);
+  assertEquals((await res.json()).error, "expression is required");
+});
+
+Deno.test("POST /eval defaults name to default", async () => {
+  let receivedName = "";
+  const server = createServer(stubDeps({
+    evaluate: (req) => {
+      receivedName = req.name ?? "";
+      return Promise.resolve({ result: null });
+    },
+  }));
+  await server.request("/eval", json({ expression: "1+1" }));
+  assertEquals(receivedName, "default");
+});
+
+// --- POST /screenshot ---
+
+Deno.test("POST /screenshot returns path", async () => {
+  const server = createServer(stubDeps({
+    screenshot: () => Promise.resolve("/tmp/shot.png"),
+  }));
+  const res = await server.request("/screenshot", json({ name: "default" }));
+  assertEquals(res.status, 200);
+  assertEquals(await res.json(), { path: "/tmp/shot.png" });
+});
+
+Deno.test("POST /screenshot defaults name to default", async () => {
+  let receivedName = "";
+  const server = createServer(stubDeps({
+    screenshot: (name) => {
+      receivedName = name;
+      return Promise.resolve("/tmp/shot.png");
+    },
+  }));
+  await server.request("/screenshot", json({}));
+  assertEquals(receivedName, "default");
+});
+
+// --- POST /shutdown ---
+
+Deno.test("POST /shutdown returns ok", async () => {
+  const server = createServer(stubDeps());
+  const res = await server.request("/shutdown", { method: "POST" });
+  assertEquals(res.status, 200);
+  assertEquals(await res.json(), { ok: true });
+});
+
+// --- Error handling ---
+
+Deno.test("unknown route returns 404", async () => {
+  const server = createServer(stubDeps());
+  const res = await server.request("/nonexistent");
+  assertEquals(res.status, 404);
+  assertEquals(await res.json(), { error: "not found" });
+});
+
+Deno.test("domain error returns 500 with error message", async () => {
+  const server = createServer(stubDeps({
+    navigate: () => Promise.reject(new Error("connection lost")),
+  }));
+  const res = await server.request("/pages", json({ url: "https://example.com" }));
+  assertEquals(res.status, 500);
+  assertEquals(await res.json(), { error: "connection lost" });
+});
+
+Deno.test("wrong method returns 405", async () => {
+  const server = createServer(stubDeps());
+  const res = await server.request("/health", { method: "POST" });
+  assertEquals(res.status, 405);
+  assertEquals(await res.json(), { error: "method not allowed" });
+});
+
+Deno.test("wrong method on /pages/:name returns 405", async () => {
+  const server = createServer(stubDeps());
+  const res = await server.request("/pages/foo", { method: "GET" });
+  assertEquals(res.status, 405);
+  assertEquals(await res.json(), { error: "method not allowed" });
+});
+
+Deno.test("malformed JSON returns 400", async () => {
+  const server = createServer(stubDeps());
+  const res = await server.request("/pages", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: "not json",
+  });
+  assertEquals(res.status, 400);
+  assertEquals(await res.json(), { error: "invalid JSON" });
+});
+
+Deno.test("POST /screenshot passes fullPage option", async () => {
+  let receivedFullPage: boolean | undefined;
+  const server = createServer(stubDeps({
+    screenshot: (_name, fullPage) => {
+      receivedFullPage = fullPage;
+      return Promise.resolve("/tmp/shot.png");
+    },
+  }));
+  await server.request("/screenshot", json({ name: "default", fullPage: true }));
+  assertEquals(receivedFullPage, true);
+});

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -1,0 +1,169 @@
+import type {
+  EvalRequest,
+  EvalResult,
+  NavigateRequest,
+  PageInfo,
+  SnapshotOptions,
+  SnapshotResult,
+} from "../domain/mod.ts";
+
+/** Dependencies injected from main.ts composition root. */
+export interface ServerDeps {
+  navigate(req: NavigateRequest): Promise<PageInfo>;
+  evaluate(req: EvalRequest): Promise<EvalResult>;
+  screenshot(name: string, fullPage?: boolean): Promise<string>;
+  listPages(): Promise<PageInfo[]>;
+  closePage(name: string): Promise<void>;
+  snapshot(options: SnapshotOptions): Promise<SnapshotResult>;
+}
+
+/** Handle returned by createServer — testable via .request(), servable via .serve(). */
+export interface Server {
+  /** Send a synthetic request to the handler (for testing). */
+  request(path: string, init?: RequestInit): Promise<Response>;
+  /** Start listening on given port and hostname. Returns the Deno.HttpServer for lifecycle. */
+  serve(options: { port: number; hostname: string }): Deno.HttpServer;
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function errorResponse(message: string, status: number): Response {
+  return jsonResponse({ error: message }, status);
+}
+
+async function readJson(req: Request): Promise<Record<string, unknown> | null> {
+  try {
+    return (await req.json()) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+type Route = {
+  methods: string[];
+  handle: (req: Request, match: RegExpExecArray) => Response | Promise<Response>;
+};
+
+/** Create a server with injected domain dependencies. */
+export function createServer(deps: ServerDeps): Server {
+  let httpServer: Deno.HttpServer | undefined;
+
+  const routes: [RegExp, Route][] = [
+    [/^\/health$/, {
+      methods: ["GET"],
+      handle: async () => {
+        const pages = await deps.listPages();
+        return jsonResponse({ status: "ok", pages });
+      },
+    }],
+    [/^\/pages$/, {
+      methods: ["GET", "POST"],
+      handle: async (req) => {
+        if (req.method === "GET") {
+          const pages = await deps.listPages();
+          return jsonResponse(pages);
+        }
+        const body = await readJson(req);
+        if (!body) return errorResponse("invalid JSON", 400);
+        if (!body.url) return errorResponse("url is required", 400);
+        const result = await deps.navigate({
+          name: (body.name as string) ?? undefined,
+          url: body.url as string,
+        });
+        return jsonResponse(result);
+      },
+    }],
+    [/^\/pages\/([^/]+)$/, {
+      methods: ["DELETE"],
+      handle: async (_req, match) => {
+        await deps.closePage(decodeURIComponent(match[1]));
+        return jsonResponse({ ok: true });
+      },
+    }],
+    [/^\/snapshot$/, {
+      methods: ["POST"],
+      handle: async (req) => {
+        const body = await readJson(req);
+        const opts = body ?? {};
+        const options: SnapshotOptions = {
+          name: (opts.name as string) ?? "default",
+          maxDepth: opts.maxDepth as number | undefined,
+          maxNodes: opts.maxNodes as number | undefined,
+          selector: opts.selector as string | undefined,
+        };
+        const result = await deps.snapshot(options);
+        return jsonResponse(result);
+      },
+    }],
+    [/^\/eval$/, {
+      methods: ["POST"],
+      handle: async (req) => {
+        const body = await readJson(req);
+        if (!body) return errorResponse("invalid JSON", 400);
+        if (!body.expression) return errorResponse("expression is required", 400);
+        const result = await deps.evaluate({
+          name: (body.name as string) ?? "default",
+          expression: body.expression as string,
+        });
+        return jsonResponse(result);
+      },
+    }],
+    [/^\/screenshot$/, {
+      methods: ["POST"],
+      handle: async (req) => {
+        const body = await readJson(req);
+        const opts = body ?? {};
+        const name = (opts.name as string) ?? "default";
+        const fullPage = opts.fullPage as boolean | undefined;
+        const filePath = await deps.screenshot(name, fullPage);
+        return jsonResponse({ path: filePath });
+      },
+    }],
+    [/^\/shutdown$/, {
+      methods: ["POST"],
+      handle: () => {
+        if (httpServer) {
+          const ref = httpServer;
+          queueMicrotask(() => ref.shutdown());
+        }
+        return jsonResponse({ ok: true });
+      },
+    }],
+  ];
+
+  const handler = async (req: Request): Promise<Response> => {
+    const url = new URL(req.url);
+    const path = url.pathname;
+
+    try {
+      for (const [pattern, route] of routes) {
+        const match = pattern.exec(path);
+        if (!match) continue;
+        if (!route.methods.includes(req.method)) {
+          return errorResponse("method not allowed", 405);
+        }
+        return await route.handle(req, match);
+      }
+      return errorResponse("not found", 404);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "internal server error";
+      return errorResponse(message, 500);
+    }
+  };
+
+  return {
+    request(path: string, init?: RequestInit): Promise<Response> {
+      const url = path.startsWith("http") ? path : `http://localhost${path}`;
+      return handler(new Request(url, init));
+    },
+    serve(options: { port: number; hostname: string }): Deno.HttpServer {
+      httpServer = Deno.serve({ ...options, onListen: () => {} }, handler);
+      return httpServer;
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- Implement `createServer` factory with dependency injection for all domain operations
- All 8 design-doc routes: `GET /health`, `POST /pages`, `DELETE /pages/:name`, `GET /pages`, `POST /snapshot`, `POST /eval`, `POST /screenshot`, `POST /shutdown`
- Structured regex router with 405/404/400/500 error handling, JSON validation, page name defaulting to `"default"`

Closes #3

## Test Plan
- [x] `deno task ci` passes (110 tests, 21 HTTP-specific)
- [x] roborev review passed (all findings addressed)

Generated with [Claude Code](https://claude.com/claude-code)