### PR TITLE
HTTP server: enforce loopback, test lifecycle, reject bad JSON

### DIFF
--- a/src/http/server.test.ts
+++ b/src/http/server.test.ts
@@ -237,6 +237,15 @@ Deno.test("malformed JSON returns 400", async () => {
   assertEquals(await res.json(), { error: "invalid JSON" });
 });
 
+Deno.test("non-object JSON body returns 400", async () => {
+  const server = createServer(stubDeps());
+  for (const body of [[], "string", 42, true]) {
+    const res = await server.request("/snapshot", json(body));
+    assertEquals(res.status, 400, `body ${JSON.stringify(body)} should be rejected`);
+    assertEquals(await res.json(), { error: "invalid JSON" });
+  }
+});
+
 Deno.test("malformed JSON on /snapshot returns 400", async () => {
   const server = createServer(stubDeps());
   const res = await server.request("/snapshot", {

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -38,7 +38,9 @@ function errorResponse(message: string, status: number): Response {
 
 async function readJson(req: Request): Promise<Record<string, unknown> | null> {
   try {
-    return (await req.json()) as Record<string, unknown>;
+    const parsed: unknown = await req.json();
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return null;
+    return parsed as Record<string, unknown>;
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary
- `serve()` hardcodes `127.0.0.1` instead of accepting arbitrary hostname — enforces loopback-only binding
- Added real `Deno.serve` tests: verifies loopback address, tests `/shutdown` stops the server via `httpServer.finished`
- `/snapshot` and `/screenshot` now return `400 invalid JSON` on malformed bodies instead of silently falling through to defaults

Closes #3

## Test Plan
- [x] `deno task ci` passes (114 tests, 25 HTTP-specific)

Generated with [Claude Code](https://claude.com/claude-code)