### PR TITLE
Add daemon E2E smoke test

### DIFF
--- a/.claude/skills/ralph/SKILL.md
+++ b/.claude/skills/ralph/SKILL.md
@@ -64,38 +64,39 @@ deno task ci
 git add .
 ```
 
-Run `roborev review` exactly once — each invocation is a paid review. **NEVER re-run this command**
-to "retry" — a second run creates a second paid review.
+Run `roborev review` exactly once — each invocation is a paid review. **NEVER re-run to "retry".**
 
-Use this exact command (the trailing `echo` prevents the Bash tool from framing exit 1 as an error):
-
-```bash
-roborev review --dirty --wait; echo "ROBOREV_EXIT=$?"
-```
-
-### Reading results
-
-`--wait` produces **no stdout** — all signal is in the exit code captured by the `echo`:
-
-- `ROBOREV_EXIT=0` → review passed → proceed to Phase 5
-- `ROBOREV_EXIT=1` → review has findings (this is NOT a failure) → read them
-
-**IMPORTANT**: exit 1 means "findings exist", not "command failed". Do NOT re-run the command.
-
-To read findings, get the job ID from `roborev status`, then `roborev show <job-id>`:
+### Step 1: Submit
 
 ```bash
-roborev status          # find latest job ID
-roborev show <job-id>   # read findings (only works after job finishes)
+roborev review --dirty
 ```
 
-If `roborev show` says "no review found", the job is still running — check `roborev status` and
-wait.
+This prints a job ID and returns immediately. Note the job ID.
 
-**PASS**: proceed. **FAIL**: read findings with `roborev show`. Exercise judgment — fix findings you
-agree with at any severity, skip ones you don't. You have better context than a separate fix agent.
-Re-validate with `deno task ci`, then re-review once more (max 2 paid reviews per issue). After the
-2nd review: fix what you agree with, proceed — no further reviews.
+### Step 2: Wait for results
+
+Poll until the job finishes (usually 30-90 seconds):
+
+```bash
+roborev status
+```
+
+When status shows the job is complete, read findings:
+
+```bash
+roborev show <job-id>
+```
+
+If `roborev show` says "no review found", the job is still running — wait and re-check status.
+
+### Step 3: Act on findings
+
+- **No findings**: proceed to Phase 5.
+- **Has findings**: exercise judgment — fix findings you agree with at any severity, skip ones you
+  don't. You have better context than a separate fix agent. Re-validate with `deno task ci`, then
+  re-review once more (max 2 paid reviews per issue). After the 2nd review: fix what you agree with,
+  proceed — no further reviews.
 
 ---
 

--- a/.claude/skills/work/SKILL.md
+++ b/.claude/skills/work/SKILL.md
@@ -59,38 +59,39 @@ deno task ci
 git add .
 ```
 
-Run `roborev review` exactly once — each invocation is a paid review. **NEVER re-run this command**
-to "retry" — a second run creates a second paid review.
+Run `roborev review` exactly once — each invocation is a paid review. **NEVER re-run to "retry".**
 
-Use this exact command (the trailing `echo` prevents the Bash tool from framing exit 1 as an error):
-
-```bash
-roborev review --dirty --wait; echo "ROBOREV_EXIT=$?"
-```
-
-### Reading results
-
-`--wait` produces **no stdout** — all signal is in the exit code captured by the `echo`:
-
-- `ROBOREV_EXIT=0` → review passed → proceed to Phase 4
-- `ROBOREV_EXIT=1` → review has findings (this is NOT a failure) → read them
-
-**IMPORTANT**: exit 1 means "findings exist", not "command failed". Do NOT re-run the command.
-
-To read findings, get the job ID from `roborev status`, then `roborev show <job-id>`:
+### Step 1: Submit
 
 ```bash
-roborev status          # find latest job ID
-roborev show <job-id>   # read findings (only works after job finishes)
+roborev review --dirty
 ```
 
-If `roborev show` says "no review found", the job is still running — check `roborev status` and
-wait.
+This prints a job ID and returns immediately. Note the job ID.
 
-**PASS**: proceed. **FAIL**: read findings with `roborev show`. Exercise judgment — fix findings you
-agree with at any severity, skip ones you don't. You have better context than a separate fix agent.
-Re-validate with `deno task ci`, then re-review once more (max 2 paid reviews per issue). After the
-2nd review: fix what you agree with, proceed — no further reviews.
+### Step 2: Wait for results
+
+Poll until the job finishes (usually 30-90 seconds):
+
+```bash
+roborev status
+```
+
+When status shows the job is complete, read findings:
+
+```bash
+roborev show <job-id>
+```
+
+If `roborev show` says "no review found", the job is still running — wait and re-check status.
+
+### Step 3: Act on findings
+
+- **No findings**: proceed to Phase 4.
+- **Has findings**: exercise judgment — fix findings you agree with at any severity, skip ones you
+  don't. You have better context than a separate fix agent. Re-validate with `deno task ci`, then
+  re-review once more (max 2 paid reviews per issue). After the 2nd review: fix what you agree with,
+  proceed — no further reviews.
 
 ---
 

--- a/ralph.sh
+++ b/ralph.sh
@@ -9,6 +9,7 @@
 # Loop continues until all issues are complete.
 
 set -e
+trap 'echo ""; echo "Interrupted."; exit 130' INT TERM
 
 if [ $# -eq 0 ]; then
     echo "Usage: ./ralph.sh \"<milestone-name>\""

--- a/src/cdp/chrome.ts
+++ b/src/cdp/chrome.ts
@@ -21,7 +21,7 @@ function findFreePort(): number {
 }
 
 /** Wait for Chrome's /json/version endpoint to become available. */
-async function waitForChrome(port: number, maxRetries = 20, delay = 150): Promise<void> {
+async function waitForChrome(port: number, maxRetries = 40, delay = 250): Promise<void> {
   for (let i = 0; i < maxRetries; i++) {
     try {
       const res = await fetch(`http://127.0.0.1:${port}/json/version`);
@@ -73,8 +73,10 @@ export async function launchChrome(options?: LaunchOptions): Promise<ChromeProce
   const chromePath = options?.chromePath ?? findChromePath();
   const headless = options?.headless ?? true;
 
+  const userDataDir = Deno.makeTempDirSync({ prefix: "scraper-chrome-" });
   const args = [
     `--remote-debugging-port=${port}`,
+    `--user-data-dir=${userDataDir}`,
     "--no-first-run",
     "--no-default-browser-check",
     "--disable-background-networking",
@@ -84,6 +86,7 @@ export async function launchChrome(options?: LaunchOptions): Promise<ChromeProce
     "--disable-translate",
     "--mute-audio",
     "--no-sandbox",
+    "--use-mock-keychain",
   ];
   if (headless) {
     args.unshift("--headless=new");

--- a/src/cdp/chrome.ts
+++ b/src/cdp/chrome.ts
@@ -4,6 +4,7 @@ export interface ChromeProcess {
   pid: number;
   port: number;
   process: Deno.ChildProcess;
+  userDataDir: string;
 }
 
 export interface LaunchOptions {
@@ -99,7 +100,7 @@ export async function launchChrome(options?: LaunchOptions): Promise<ChromeProce
     stderr: "null",
   });
   const process = command.spawn();
-  const chrome: ChromeProcess = { pid: process.pid, port, process };
+  const chrome: ChromeProcess = { pid: process.pid, port, process, userDataDir };
 
   try {
     await waitForChrome(port);
@@ -111,7 +112,7 @@ export async function launchChrome(options?: LaunchOptions): Promise<ChromeProce
   return chrome;
 }
 
-/** Kill a Chrome process. */
+/** Kill a Chrome process and clean up its user data directory. */
 export async function killChrome(chrome: ChromeProcess): Promise<void> {
   try {
     chrome.process.kill("SIGTERM");
@@ -123,5 +124,10 @@ export async function killChrome(chrome: ChromeProcess): Promise<void> {
     await chrome.process.status;
   } catch {
     // Process already exited
+  }
+  try {
+    await Deno.remove(chrome.userDataDir, { recursive: true });
+  } catch {
+    // Best effort cleanup
   }
 }

--- a/tests/integration/daemon.test.ts
+++ b/tests/integration/daemon.test.ts
@@ -1,0 +1,147 @@
+/** Daemon E2E smoke test: exercises the full public surface through main.ts. */
+
+import { assert, assertEquals } from "@std/assert";
+import { startFixtureServer } from "./fixture-server.ts";
+
+function findFreePort(): number {
+  const listener = Deno.listen({ port: 0, hostname: "127.0.0.1" });
+  const port = (listener.addr as Deno.NetAddr).port;
+  listener.close();
+  return port;
+}
+
+async function waitForHealth(port: number, timeoutMs = 30_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/health`);
+      await res.body?.cancel();
+      if (res.ok) return;
+    } catch {
+      // not ready yet
+    }
+    await new Promise((r) => setTimeout(r, 200));
+  }
+  throw new Error(`daemon did not become healthy within ${timeoutMs}ms`);
+}
+
+/** Resolve Deno's cache directory so it survives HOME override. */
+async function denoDir(): Promise<string> {
+  const cmd = new Deno.Command(Deno.execPath(), {
+    args: ["info", "--json"],
+    stdout: "piped",
+    stderr: "null",
+  });
+  const { stdout } = await cmd.output();
+  return JSON.parse(new TextDecoder().decode(stdout)).denoDir;
+}
+
+Deno.test("daemon E2E: start → navigate → snapshot → eval → stop", async () => {
+  const tmpHome = await Deno.makeTempDir();
+  const port = findFreePort();
+  const fixtures = startFixtureServer();
+  const env = { ...Deno.env.toObject(), HOME: tmpHome, DENO_DIR: await denoDir() };
+  const base = `http://127.0.0.1:${port}`;
+
+  const daemon = new Deno.Command(Deno.execPath(), {
+    args: ["run", "--allow-all", "src/main.ts", "start", "--port", String(port)],
+    env,
+    stdout: "piped",
+    stderr: "piped",
+  }).spawn();
+
+  // Drain stdout/stderr to prevent blocking — collect for diagnostics.
+  const stdoutChunks: Uint8Array[] = [];
+  const stderrChunks: Uint8Array[] = [];
+  const drainStdout = (async () => {
+    for await (const chunk of daemon.stdout) stdoutChunks.push(chunk);
+  })();
+  const drainStderr = (async () => {
+    for await (const chunk of daemon.stderr) stderrChunks.push(chunk);
+  })();
+
+  const decode = (chunks: Uint8Array[]) =>
+    new TextDecoder().decode(new Uint8Array(chunks.flatMap((c) => [...c])));
+
+  try {
+    await waitForHealth(port).catch((e) => {
+      throw new Error(
+        `${e.message}\ndaemon stdout: ${decode(stdoutChunks)}\ndaemon stderr: ${
+          decode(stderrChunks)
+        }`,
+      );
+    });
+
+    // /health responds
+    const healthRes = await fetch(`${base}/health`);
+    assertEquals((await healthRes.json()).status, "ok");
+
+    // Navigate to fixture page
+    const navRes = await fetch(`${base}/pages`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ url: fixtures.url("bestseller-table.html"), name: "smoke" }),
+    });
+    assertEquals(navRes.status, 200);
+    await navRes.body?.cancel();
+
+    // Snapshot — one structural marker
+    const snapRes = await fetch(`${base}/snapshot`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "smoke" }),
+    });
+    assertEquals(snapRes.status, 200);
+    const snap = await snapRes.json();
+    assert(snap.yaml.includes("table"), "snapshot YAML should contain table role");
+
+    // Eval — one JSON result
+    const evalRes = await fetch(`${base}/eval`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "smoke",
+        expression: "document.querySelector('h1').textContent",
+      }),
+    });
+    assertEquals(evalRes.status, 200);
+    assertEquals((await evalRes.json()).result, "Top Bestselling Books");
+
+    // Stop via CLI subprocess
+    const stopResult = await new Deno.Command(Deno.execPath(), {
+      args: ["run", "--allow-all", "src/main.ts", "stop"],
+      env,
+      stdout: "piped",
+      stderr: "piped",
+    }).output();
+    assertEquals(stopResult.code, 0, `stop failed: ${new TextDecoder().decode(stopResult.stderr)}`);
+
+    // Daemon exited cleanly
+    const status = await daemon.status;
+    assertEquals(status.code, 0, "daemon should exit with code 0");
+
+    // PID file removed
+    try {
+      await Deno.stat(`${tmpHome}/.scraper/daemon.json`);
+      throw new Error("PID file should have been removed");
+    } catch (e) {
+      assert(e instanceof Deno.errors.NotFound, "PID file should not exist after stop");
+    }
+  } finally {
+    try {
+      const r = await fetch(`${base}/shutdown`, { method: "POST" });
+      await r.body?.cancel();
+    } catch { /* may already be stopped */ }
+    try {
+      daemon.kill("SIGTERM");
+    } catch { /* may already be dead */ }
+    try {
+      await daemon.status;
+    } catch { /* ignore */ }
+    await Promise.allSettled([drainStdout, drainStderr]);
+    await fixtures.close();
+    try {
+      await Deno.remove(tmpHome, { recursive: true });
+    } catch { /* best effort */ }
+  }
+});


### PR DESCRIPTION
## Summary
- Full lifecycle E2E test: start → navigate → snapshot → eval → stop → verify clean exit
- Fix Chrome macOS keychain dialog with `--use-mock-keychain` and isolated `--user-data-dir`
- Clean up temp user-data-dir in `killChrome` to prevent temp dir leaks
- Fix `ralph.sh` Ctrl-C handling and rewrite roborev skill instructions

Closes #18

## Test Plan
- [x] `deno task ci` passes (171 tests)
- [x] roborev review passed

Generated with [Claude Code](https://claude.com/claude-code)